### PR TITLE
Fix multiple pickers on iOS, add value formatter

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/ComboPickerExample/ComboPickerExample.xcodeproj/project.pbxproj
+++ b/Examples/ComboPickerExample/ComboPickerExample.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		FA61501A286CDDCF00ADEE20 /* ExampleModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614FF6286CDBAC00ADEE20 /* ExampleModel.swift */; };
 		FA61501B286CDDD300ADEE20 /* ExampleModel+StaticData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA614FF8286CDBB100ADEE20 /* ExampleModel+StaticData.swift */; };
 		FA61501D286CDE1700ADEE20 /* ComboPicker in Frameworks */ = {isa = PBXBuildFile; productRef = FA61501C286CDE1700ADEE20 /* ComboPicker */; };
+		FADCE652287191B1004BC0CB /* ExampleModelFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADCE651287191B1004BC0CB /* ExampleModelFormatter.swift */; };
+		FADCE65328719284004BC0CB /* ExampleModelFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADCE651287191B1004BC0CB /* ExampleModelFormatter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +65,7 @@
 		FA615009286CDD6900ADEE20 /* ComboPickerWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComboPickerWatchApp.swift; sourceTree = "<group>"; };
 		FA61500D286CDD6A00ADEE20 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		FA615010286CDD6A00ADEE20 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		FADCE651287191B1004BC0CB /* ExampleModelFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleModelFormatter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -140,6 +143,7 @@
 			children = (
 				FA614FF6286CDBAC00ADEE20 /* ExampleModel.swift */,
 				FA614FF8286CDBB100ADEE20 /* ExampleModel+StaticData.swift */,
+				FADCE651287191B1004BC0CB /* ExampleModelFormatter.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -306,6 +310,7 @@
 				FA614FE9286CDB8F00ADEE20 /* ContentView.swift in Sources */,
 				FA614FE7286CDB8F00ADEE20 /* ComboPickerExampleApp.swift in Sources */,
 				FA614FF9286CDBB100ADEE20 /* ExampleModel+StaticData.swift in Sources */,
+				FADCE652287191B1004BC0CB /* ExampleModelFormatter.swift in Sources */,
 				FA614FF7286CDBAC00ADEE20 /* ExampleModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -317,6 +322,7 @@
 				FA615019286CDDB900ADEE20 /* ContentView.swift in Sources */,
 				FA61500A286CDD6900ADEE20 /* ComboPickerWatchApp.swift in Sources */,
 				FA61501B286CDDD300ADEE20 /* ExampleModel+StaticData.swift in Sources */,
+				FADCE65328719284004BC0CB /* ExampleModelFormatter.swift in Sources */,
 				FA61501A286CDDCF00ADEE20 /* ExampleModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/ComboPickerExample/ComboPickerExample/ContentView.swift
+++ b/Examples/ComboPickerExample/ComboPickerExample/ContentView.swift
@@ -8,21 +8,37 @@
 import SwiftUI
 import ComboPicker
 
+#if os(watchOS) || os(tvOS)
+typealias Stack = VStack
+#else
+typealias Stack = HStack
+#endif
+
 struct ContentView: View {
   @State private var content = ExampleModel.data
+  
   @State private var selection = ExampleModel.data.first!.value
+  @State private var otherSelection = ExampleModel.data.last!.value
   
   var body: some View {
-    VStack {
+    Stack {
       ComboPicker(
         title: "Pick a number",
         manualTitle: "Custom...",
+        valueFormatter: ExampleModelFormatter(),
         content: $content,
         value: $selection
       )
       .keyboardType(.numberPad)
       
-//      Text("Selected value: \(selection)")
+      ComboPicker(
+        title: "Pick another number",
+        manualTitle: "Custom...",
+        valueFormatter: ExampleModelFormatter(),
+        content: $content,
+        value: $otherSelection
+      )
+      .keyboardType(.numberPad)
     }
     .padding()
   }

--- a/Examples/ComboPickerExample/ComboPickerExample/Data/ExampleModel.swift
+++ b/Examples/ComboPickerExample/ComboPickerExample/Data/ExampleModel.swift
@@ -2,6 +2,10 @@ import ComboPicker
 import Foundation
 
 public struct ExampleModel: ComboPickerModel {
+  public static func ==(lhs: ExampleModel, rhs: ExampleModel) -> Bool {
+    lhs.value == rhs.value
+  }
+  
   public let id = UUID()
   public let value: Int
   
@@ -16,9 +20,5 @@ public struct ExampleModel: ComboPickerModel {
   
   public var valueForManualInput: String? {
     NumberFormatter().string(from: .init(value: value))
-  }
-  
-  public var label: String {
-    "# \(NumberFormatter().string(from: .init(value: value)) ?? "")"
   }
 }

--- a/Examples/ComboPickerExample/ComboPickerExample/Data/ExampleModelFormatter.swift
+++ b/Examples/ComboPickerExample/ComboPickerExample/Data/ExampleModelFormatter.swift
@@ -1,0 +1,15 @@
+//
+//  ExampleModelFormatter.swift
+//  ComboPickerExample
+//
+//  Created by Alessio Moiso on 03.07.22.
+//
+
+import Foundation
+import ComboPicker
+
+final class ExampleModelFormatter: ValueFormatterType {
+  func string(from value: ExampleModel) -> String {
+    "# \(NumberFormatter().string(from: .init(value: value.value)) ?? "")"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -37,15 +37,21 @@ public struct ExampleModel: ComboPickerModel {
   public var valueForManualInput: String? {
     NumberFormatter().string(from: .init(value: value))
   }
-  
-  // Value display label.
-  public var label: String {
-    "# \(NumberFormatter().string(from: .init(value: value)) ?? "")"
+}
+```
+
+You also have to provide an implementation of `ValueFormatterType`, so that the `ComboPicker` knows how to
+represent values in the `Picker`s. The following example illustrates a simple formatter for the model implemented above:
+
+```swift
+final class ExampleModelFormatter: ValueFormatterType {
+  func string(from value: ExampleModel) -> String {
+    "# \(NumberFormatter().string(from: .init(value: value.value)) ?? "")"
   }
 }
 ```
 
-Once you have a collection of models, displaying them in the `CombPicker` is easy:
+Once you have a collection of models and the formatter implementation, building a `ComboPicker` is easy:
 
 ```swift
 @State private var content: [ExampleModel]
@@ -54,6 +60,7 @@ Once you have a collection of models, displaying them in the `CombPicker` is eas
 ComboPicker(
   title: "Pick a number",
   manualTitle: "Custom...",
+  valueFormatter: ExampleModelFormatter(),
   content: $content,
   value: $selection
 )
@@ -63,7 +70,7 @@ ComboPicker(
 `ComboPicker` adapts to the platform to provide an easy and accessible experience regardless of the device.
 
 ### iOS & iPadOS
-On iOS and iPadOS, the `ComboPicker` shows a one-line `Picker` that the user can scroll. If the user taps on it, a text field for manual input appears.
+On iOS and iPadOS, the `ComboPicker` shows a one-line `UIPickerView` that the user can scroll. If the user taps on it, a text field for manual input appears.
 
 ![ComboPicker](images/iphone.gif)
 
@@ -72,6 +79,9 @@ If necessary, you can customize the keyboard type for the manual input field:
 ```swift
 .keyboardType(.numberPad)
 ```
+
+_Note: because of limitations of the SwiftUI `Picker` regarding the gestures handling, as well as the ability of showing and using multiple wheel pickers in the
+same screen, `ComboPicker` is currently relying on a `UIViewRepresentable` implementation of a `UIPickerView`. You can read more about the current limitations [here](https://stackoverflow.com/questions/69122169/ios15-swiftui-wheelpicker-scrollable-outside-frame-and-clipped-area-destructin?noredirect=1&lq=1)._
 
 ### watchOS
 On watchOS, the `ComboPicker`shows a normal `Picker` that the user can scroll using their fingers or the digital crown. If the user taps on it, a text field for manual input appears.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ ComboPicker can display any type that conforms to the `ComboPickerModel` protoco
 
 ```swift
 public struct ExampleModel: ComboPickerModel {
+  public static func ==(lhs: ExampleModel, rhs: ExampleModel) -> Bool {
+    lhs.value == rhs.value
+  }
+
   public let id = UUID()
   public let value: Int
   

--- a/Sources/ComboPicker/Protocols/ComboPickerModel.swift
+++ b/Sources/ComboPicker/Protocols/ComboPickerModel.swift
@@ -30,9 +30,6 @@ public protocol ComboPickerModel: Identifiable, Hashable {
   /// - customValue: A custom value the user input.
   init?(customValue: String)
   
-  /// Get the label to use to display this value.
-  var label: String { get }
-  
   /// Get the actual value.
   var value: Value { get }
   

--- a/Sources/ComboPicker/Protocols/ValueFormatterType.swift
+++ b/Sources/ComboPicker/Protocols/ValueFormatterType.swift
@@ -1,0 +1,19 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alessio Moiso on 03.07.22.
+//
+
+import Foundation
+
+/// A type that represents a generic formatter.
+///
+/// # Overview
+/// You can provide an implementation of this protocol to format
+/// the values you want to display in a `ComboPicker`.
+public protocol ValueFormatterType {
+  associatedtype Value
+  
+  func string(from value: Value) -> String
+}

--- a/Sources/ComboPicker/Views/iOS/NativePicker.swift
+++ b/Sources/ComboPicker/Views/iOS/NativePicker.swift
@@ -1,0 +1,72 @@
+//
+//  NativePicker.swift
+//  
+//
+//  Created by Alessio Moiso on 03.07.22.
+//
+
+#if os(iOS)
+import UIKit
+import SwiftUI
+
+/// An implementation of a `UIPickerView` compatible with SwiftUI.
+///
+/// Based on this [StackOverflow answer](https://stackoverflow.com/a/69842277/925537).
+struct NativePicker<Content: ComboPickerModel, Formatter: ValueFormatterType>: UIViewRepresentable where Formatter.Value == Content {
+  let content: Binding<[Content]>
+  var selection: Binding<Content.Value>
+  
+  let valueFormatter: Formatter
+  
+  init(content: Binding<[Content]>, selection: Binding<Content.Value>, valueFormatter: Formatter) {
+    self.content = content
+    self.selection = selection
+    self.valueFormatter = valueFormatter
+  }
+  
+  func makeCoordinator() -> Self.Coordinator {
+    Coordinator(self)
+  }
+  
+  func makeUIView(context: UIViewRepresentableContext<Self>) -> UIPickerView {
+    let picker = UIPickerView()
+    picker.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    picker.dataSource = context.coordinator
+    picker.delegate = context.coordinator
+    return picker
+  }
+  
+  func updateUIView(_ view: UIPickerView, context: UIViewRepresentableContext<Self>) {
+    guard let row = content.wrappedValue.firstIndex(where: { $0.value == selection.wrappedValue }) else { return }
+    view.selectRow(row, inComponent: 0, animated: false)
+  }
+  
+  class Coordinator: NSObject, UIPickerViewDataSource, UIPickerViewDelegate {
+    var parent: NativePicker
+    
+    init(_ pickerView: NativePicker) {
+      parent = pickerView
+    }
+    
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+      return 1
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+      return 90
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+      return parent.content.wrappedValue.count
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+      return parent.valueFormatter.string(from: parent.content.wrappedValue[row])
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+      parent.selection.wrappedValue = parent.content.wrappedValue[row].value
+    }
+  }
+}
+#endif


### PR DESCRIPTION
# Overview
This PR implements a `UIViewRepresentable` to support multiple pickers on iOS and iPadOS, as well as adding support for custom value formatters.

# References
- Closes #1 
- Closes #2