### PR TITLE
Add font customization, fix manual input

### DIFF
--- a/Examples/ComboPickerExample/ComboPickerExample/BasicView.swift
+++ b/Examples/ComboPickerExample/ComboPickerExample/BasicView.swift
@@ -39,6 +39,9 @@ struct BasicView: View {
         value: $otherSelection
       )
       .keyboardType(.numberPad)
+#if os(iOS)
+      .pickerFont(.caption2)
+#endif
     }
     .padding()
   }

--- a/Examples/ComboPickerExample/ComboPickerExample/ListView.swift
+++ b/Examples/ComboPickerExample/ComboPickerExample/ListView.swift
@@ -23,7 +23,9 @@ struct ListView: View {
         content: $content,
         value: $selection
       )
-      
+#if os(iOS)
+      .pickerFont(.headline)
+#endif
       .keyboardType(.numberPad)
       .padding()
       

--- a/Sources/ComboPicker/Views/ManualInput.swift
+++ b/Sources/ComboPicker/Views/ManualInput.swift
@@ -33,9 +33,9 @@ struct ManualInput: View {
 #if os(iOS) || os(macOS)
     HStack {
       TextField(title, text: $value)
-  #if !os(macOS)
+#if !os(macOS)
         .keyboardType(keyboardType.systemType)
-  #endif
+#endif
         .font(.system(size: 21))
         .multilineTextAlignment(.center)
         .frame(height: 30)
@@ -49,6 +49,7 @@ struct ManualInput: View {
         .background(Color.secondary.opacity(0.1))
         .cornerRadius(8)
         .padding([.leading, .trailing], 8)
+        .onSubmit(performAction)
     }
 #elseif os(watchOS)
     HStack {

--- a/Sources/ComboPicker/Views/iOS/NativePicker.swift
+++ b/Sources/ComboPicker/Views/iOS/NativePicker.swift
@@ -16,12 +16,14 @@ struct NativePicker<Content: ComboPickerModel, Formatter: ValueFormatterType>: U
   let content: Binding<[Content]>
   var selection: Binding<Content.Value>
   
+  let font: UIFont?
   let valueFormatter: Formatter
   
-  init(content: Binding<[Content]>, selection: Binding<Content.Value>, valueFormatter: Formatter) {
+  init(content: Binding<[Content]>, selection: Binding<Content.Value>, valueFormatter: Formatter, font: UIFont? = nil) {
     self.content = content
     self.selection = selection
     self.valueFormatter = valueFormatter
+    self.font = font
   }
   
   func makeCoordinator() -> Self.Coordinator {
@@ -56,8 +58,26 @@ struct NativePicker<Content: ComboPickerModel, Formatter: ValueFormatterType>: U
       return parent.content.wrappedValue.count
     }
     
-    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-      return parent.valueFormatter.string(from: parent.content.wrappedValue[row])
+    func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+      let value = parent.valueFormatter.string(from: parent.content.wrappedValue[row])
+      
+      if
+        let view = view as? UILabel,
+        (view.font == parent.font || parent.font == nil)
+      {
+        view.text = value
+        return view
+      }
+      
+      let label = UILabel()
+      // Use the default text size for pickers, unless a different font is specified.
+      // This is necessary to mimic the standard behavior, when the delegate only returns strings.
+      label.font = parent.font ?? .systemFont(ofSize: 21)
+      label.text = value
+      label.textAlignment = .center
+      label.adjustsFontForContentSizeCategory = true
+      
+      return label
     }
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {


### PR DESCRIPTION
# Overview
This PR adds the ability to provide a custom font on iOS and iPadOS, as well as fixing the manual input not adding values on macOS and tvOS.

# References
- Closes #7 
- Closes #5 